### PR TITLE
Modify update method to not return the entire dataset for performance

### DIFF
--- a/backend/controllers/data.controller.js
+++ b/backend/controllers/data.controller.js
@@ -61,7 +61,7 @@ const putData = asyncHandler(async (req, res) => {
     throw new Error("Device does not exist");
   }
 
-  const updatedData = await Data.findOneAndUpdate(
+  const updatedReport = await Data.updateOne(
     { serial: req.params.serial },
     {
       $push: {
@@ -79,7 +79,7 @@ const putData = asyncHandler(async (req, res) => {
     }
   );
 
-  res.status(200).json(updatedData);
+  res.status(200).json(updatedReport);
 });
 
 module.exports = {


### PR DESCRIPTION
Let me know if returning object on update is a required behavior for the frontend, I don't need that on my side and it is causing timeouts
in the case it is needed I will probably add another patch to this PR to call to the db to fetch the last 100 element.